### PR TITLE
Dreamcompute instance and volume migration

### DIFF
--- a/source/dreamcompute/tutorials/how-to-migrate-instances-between-clusters.rst
+++ b/source/dreamcompute/tutorials/how-to-migrate-instances-between-clusters.rst
@@ -14,7 +14,7 @@ show you how to accomplish this yourself.
 
 This guide assumes that you are comfortable working with SSH, and some
 command line utilities such as `dd <http://man7.org/linux/man-pages/man1/dd.1.html>`_
-and in some cases `glance <http://docs.openstack.org/developer/python-glanceclient/man/glance.html>`_.
+and `glance <http://docs.openstack.org/developer/python-glanceclient/man/glance.html>`_.
 
 Things To Keep in Mind
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -57,7 +57,7 @@ Here are a few things to keep in mind and plan while doing a migration.
   have their data accessed by another instance.  These instances can only be
   migrated while running, so it is best to shut down as many services like
   MySQL, apache, and so on to limit possible corruption.  Please see the last
-  section below on how to move migrate running instances.
+  section below on how to migrate running instances.
 
 Migrate a Volume-backed Instance using Glance
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -72,12 +72,12 @@ As an overview, we are going to setup the following to accomplish this task.
 
 .. code::
 
-        SOURCE CLUSTER           DESTINATION CLUSTER
+        SOURCE CLUSTER         DESTINATION CLUSTER
 
-       +---------------+       +----------------------+
-       | Copy Instance |------>| Glance Image Service |
-       +---------------+       +----------------------+
-               |
+       +---------------+     +----------------------+     +-------------------+
+       | Temp Instance |---->| Glance Image Service |---->| Migrated Instance |
+       +---------------+     +----------------------+     +-------------------+
+               |(mount)
        +----------------+
        | Volume To Copy |
        +----------------+
@@ -226,4 +226,4 @@ instance and to select the image we just uploaded.  It is best to use a volume
 instead of ephemeral in this situation if the data is meant to be persistent.
 
 .. meta::
-    :labels: apache ubuntu debian linux
+    :labels: glance migrate image

--- a/source/dreamcompute/tutorials/how-to-migrate-instances-between-clusters.rst
+++ b/source/dreamcompute/tutorials/how-to-migrate-instances-between-clusters.rst
@@ -1,0 +1,229 @@
+======================================================
+How to Migrate Instances Between DreamCompute Clusters
+======================================================
+
+Introduction
+~~~~~~~~~~~~
+
+DreamCompute offers multiple clusters (also often called availability zones)
+which are independent OpenStack installations with their own servers, storage
+and control panel.  Some clusters have different features, such as SSD storage
+or different hardware that is useful for a given task.  Migrating instances
+and data between clusters is not automated at this time, and this guide will
+show you how to accomplish this yourself.
+
+This guide assumes that you are comfortable working with SSH, and some
+command line utilities such as `dd <http://man7.org/linux/man-pages/man1/dd.1.html>`_
+and in some cases `glance <http://docs.openstack.org/developer/python-glanceclient/man/glance.html>`_.
+
+Things To Keep in Mind
+~~~~~~~~~~~~~~~~~~~~~~
+
+Here are a few things to keep in mind and plan while doing a migration.
+
+* **IP Addresses Will Change**
+
+  Each cluster has assigned blocks of IP addresses, and therefore floating IPs
+  or public IPv4 and IPv6 addresses cannot be transferred between clusters.  If
+  you are using private networks (required in US-East 1 and optional in
+  US-East 2, the specific assigned 10.x.x.x address may also change.
+
+* **SSH Keys**
+
+  Each cluster manages its SSH Keys separately, so if you have your keys
+  already setup in US-East 1, you will have to setup the same keys or new
+  ones in US-East 2.  If OpenStack generated the SSH Key for you, it let you
+  download the private key but the public key is what you would need for an
+  import.  You could grab it from /home/dhc-user/.ssh/authorized_keys on an
+  instance that used the key.  For the instances themselves, the
+  authorized_keys file isn't overwritten, only appended, and so whatever keys
+  are currently setup will continue to work after the move.
+
+* **Plan A Maintenance Window**
+
+  It is safest to move the data when the instance is not running, to avoid open
+  files causing corruption or other odd behavior.  The copying of the data is
+  generally pretty quick for smaller volumes, but for larger volumes could take
+  some time.  The copy needs to complete before service can be restored.  Also,
+  DNS will need to be updated from the previous public IPs to the new ones.
+  Depending on the TTL (time to live) of your DNS provider, this process can be
+  a matter of minutes, or take 24 hours.  DreamHost managed DNS can have the
+  TTL changed from 4 hours to 5 minutes if you contact support, and can help
+  minimize propagation time.
+
+* **Epheramal Instances**
+
+  Ephemeral instances cannot have snapshots taken, and when shutdown cannot
+  have their data accessed by another instance.  These instances can only be
+  migrated while running, so it is best to shut down as many services like
+  MySQL, apache, and so on to limit possible corruption.  Please see the last
+  section below on how to move migrate running instances.
+
+Migrate a Volume-backed Instance using Glance
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For this type of move, we will have to delete the instance so that it leaves
+behind the volume to migrate.  This method requires that you didn't checkmark
+the "delete on terminate" checkbox when you created your instance.  If you did,
+please skip to the last section on migrating running instances.  If you
+continue you may permanently destroy and lose your data.
+
+As an overview, we are going to setup the following to accomplish this task.
+
+.. code::
+
+        SOURCE CLUSTER           DESTINATION CLUSTER
+
+       +---------------+       +----------------------+
+       | Copy Instance |------>| Glance Image Service |
+       +---------------+       +----------------------+
+               |
+       +----------------+
+       | Volume To Copy |
+       +----------------+
+
+Here we go!
+
+1.  Create a new instance, using the smallest available flavor, to be used as
+a copy machine.  For this guide, I will be using Ubuntu 14.04, however the
+commands should be similar on any Ubuntu system.  I would recommend making the
+instance ephemeral, since we won't be planning to keep it.
+
+2.  Install the needed software to work with glance on this new instance.
+
+.. code:: bash
+
+    apt-get install python-dev python-pip
+    pip install python-openstackclient
+    pip install python-glanceclient
+
+After this, run "glance help" and check for any other modules that it says are
+missing.  Install them with:
+
+.. code:: bash
+
+    pip install MODULENAME
+
+3.  Setup your openstack RC file for the DESTINATION cluster on this new
+instance, which can be downloaded from its Access & Security -> API Access menu
+in the dashboard.  Either upload the file to your instance, or copy/paste its
+contents into a file on this instance.  Once you are run, you can run it like
+so.
+
+.. code:: bash
+
+    vi dreamcompute-CLUSTER.sh
+    <paste the contents, save>
+    . dreamcompute-CLUSTER.sh
+
+It will then prompt you to "Please enter your OpenStack Password:", and go
+ahead and do that.
+
+If you run a command like the below, it should output the current OS images
+in the destination cluster.
+
+.. code:: bash
+
+    glance image-list
+
+4.  Delete the instance that you wish to move, freeing up its volume to be
+attached to the above newly created instance.
+
+5.  Attach the volume to the new instance, in the Volumes menu by clicking the
+drop-down on the right side, and then "Edit Attachments".
+
+6.  On the new instance, check "dmesg" for the drive letter, or you can check
+the usual names for it, until you find the volume.
+
+.. code:: bash
+
+    fdisk -l /dev/vdb | grep Disk
+    fdisk -l /dev/vdc | grep Disk
+
+One of those should match the size of the volume you are trying to move.  Make
+note of the drive letter (the /dev/vdX part).
+
+7.  Now we will copy the data to glance, using dd and piping it directly.
+Don't forget to change the drive letter in the example to the one you found
+above, and change any text in all CAPS to suit your taste.
+
+.. code:: bash
+
+    dd if=/dev/vdX | glance --os-image-api-version 1 image-create \
+        --name "INSTANCENAME" --is-public false --disk-format raw \
+        --container-format bare
+
+8.  Wait while this runs, and if successful it should output the info about the
+new image that was created.
+
+9.  You are now ready to go to the DESTINATION cluster to start up a new
+instance and to select the image we just uploaded.  It is best to use a volume
+instead of ephemeral in this situation if the data is meant to be persistent.
+
+Migrate an Ephemeral Instance using Glance
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This type of migration is not recommended.  It may be necessary in some
+situations however and so is included here.
+
+1.  Shut down as many services as possible, such as database servers, http
+servers, etc, leaving hopefully just default system tools and sshd running.
+
+2.  Install the needed software to work with glance on this new instance.
+
+.. code:: bash
+
+    apt-get install python-dev python-pip
+    pip install python-openstackclient
+    pip install python-glanceclient
+
+After this, run "glance help" and check for any other modules that it says are
+missing.  Install them with:
+
+.. code:: bash
+
+    pip install MODULENAME
+
+3.  Setup your openstack RC file for the DESTINATION cluster on this new
+instance, which can be downloaded from its Access & Security -> API Access menu
+in the dashboard.  Either upload the file to your instance, or copy/paste its
+contents into a file on this instance.  Once you are run, you can run it like
+so.
+
+.. code:: bash
+
+    vi dreamcompute-CLUSTER.sh
+    <paste the contents, save>
+    . dreamcompute-CLUSTER.sh
+
+It will then prompt you to "Please enter your OpenStack Password:", and go
+ahead and do that.
+
+If you run a command like the below, it should output the current OS images
+in the destination cluster.
+
+.. code:: bash
+
+    glance image-list
+
+4.  Determine the drive letter by examining the output of "df -h" for the root
+(/) filesystem.  Generally this will be /dev/vda1.
+
+5.  Now we will copy the data to glance, using dd and piping it directly.
+Change any text in all CAPS to suit your taste.
+
+.. code:: bash
+
+    dd if=/dev/vda | glance --os-image-api-version 1 image-create \
+        --name "INSTANCENAME" --is-public false --disk-format raw \
+        --container-format bare
+
+6.  Wait while this runs, and if successful it should output the info about the
+new image that was created.
+
+7.  You are now ready to go to the DESTINATION cluster to start up a new
+instance and to select the image we just uploaded.  It is best to use a volume
+instead of ephemeral in this situation if the data is meant to be persistent.
+
+.. meta::
+    :labels: apache ubuntu debian linux

--- a/source/dreamcompute/tutorials/how-to-migrate-instances-between-clusters.rst
+++ b/source/dreamcompute/tutorials/how-to-migrate-instances-between-clusters.rst
@@ -51,7 +51,7 @@ Here are a few things to keep in mind and plan while doing a migration.
   TTL changed from 4 hours to 5 minutes if you contact support, and can help
   minimize propagation time.
 
-* **Epheramal Instances**
+* **Ephemeral Instances**
 
   Ephemeral instances cannot have snapshots taken, and when shutdown cannot
   have their data accessed by another instance.  These instances can only be

--- a/source/dreamcompute/tutorials/how-to-migrate-volumes-between-clusters.rst
+++ b/source/dreamcompute/tutorials/how-to-migrate-volumes-between-clusters.rst
@@ -1,0 +1,118 @@
+====================================================
+How to Migrate Volumes Between DreamCompute Clusters
+====================================================
+
+Introduction
+~~~~~~~~~~~~
+
+DreamCompute offers multiple clusters (also often called availability zones)
+which are independent OpenStack installations with their own servers, storage
+and control panel.  Some clusters have different features, such as SSD storage
+that is useful for a given data storage plan.  Migrating data between clusters
+is not automated at this time, and this guide will show you how to accomplish
+this yourself.
+
+This guide assumes that you are comfortable working with SSH, and some
+command line utilities such as `dd <http://man7.org/linux/man-pages/man1/dd.1.html>`_.
+
+Things To Keep in Mind
+~~~~~~~~~~~~~~~~~~~~~~
+
+Here are a few things to keep in mind and plan while doing a migration.
+
+* **Volumes Only**
+
+  Please see the article on migrating instances if you wish to move instances.
+  This guide focuses solely on migrating volumes, which is useful if you have
+  multiple volumes attached to an instance, and after migrating the instance
+  you want to then migrate the remaining volumes.
+
+  Also, this method does not work with ephemeral storage and is intended only
+  for volume to volume copying.
+
+* **Plan A Maintenance Window**
+
+  It is safest to move the data when the volume has no running services or open
+  files, to avoid corruption or other odd behavior.  The copying of the data is
+  generally pretty quick for smaller volumes, but for larger volumes could take
+  some time.  The copy needs to complete before service can be restored.
+
+Migrate a Volume using SSH and dd
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For this type of move, we will assume you have stopped all services using the
+data on the volume, safely unmounted it on the instance using it, and detached
+it from the instance in the Volumes menu in the dashboard.  
+
+As an overview, we are going to setup the following to accomplish this task.
+
+.. code::
+
+        SOURCE CLUSTER       DESTINATION CLUSTER
+
+       +---------------+     +---------------+
+       | Temp Instance |---->| Temp Instance |
+       +---------------+     +---------------+
+               |(mount)              |(mount)
+      +----------------+      +--------------+
+      | Volume To Copy |      |  New Volume  |
+      +----------------+      +--------------+
+
+Here we go!
+
+1.  Create two new instances, using the smallest available flavor, to be used
+as copy machines, one each in the source and destination clusters.  For this
+guide, I will be using Ubuntu 14.04, however the commands should be similar on
+any Ubuntu system.  I would recommend making the instance ephemeral, since we
+won't be planning to keep it.
+
+2.  For simplicity, we will use passwords for the two temp instances to connect
+instead of SSH keys, however you can do it either way you prefer.  To setup
+the instances for password authentication, turn it on with the below
+commands.
+
+.. code:: bash
+
+    <login to dhc-user on each instance>
+    sudo su -
+    sed -i -e 's/PasswordAuthentication no/PasswordAuthentication yes/' /etc/ssh/sshd_config
+    sed -i -e 's/PermitRootLogin without-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+    service ssh restart
+    passwd root
+    <set a password>
+
+3.  Create a matching volume in the destination cluster, that is the same size
+or larger than the source volume.
+
+4.  Attach the source volume to the instance in the source cluster, to the
+temporary instance.  Attach the destination volume to the instance in the
+destination cluster.  There is no need to mount them.
+
+5.  Determine the drive letter of the volumes on both instances.  Generally
+/dev/vda will be the boot drive of your instance, so it will be /dev/vdb or
+/dev/vdc.  You can check for it with a couple commands:
+
+.. code:: bash
+
+    fdisk -l /dev/vdb | grep Disk
+    fdisk -l /dev/vdc | grep Disk
+
+The one that matches the size of the volume is the one to use.  They may have
+different drive letters on each instance, so take note of that.
+
+6.  Now we can copy the data using dd and ssh.  For this we will login to the
+instance on the destination cluster, and use the IPv6 address for simplicity.
+Replace IPV6-OF-SOURCE-INSTANCE with the IPv6 address of the source instance
+and the first /dev/vdX with the drive letter of the source volume, and the
+second /dev/vdX with the drive letter of the destination volume.
+
+.. code:: bash
+
+    ssh root@IPV6-OF-SOURCE-INSTANCE "dd if=/dev/vdX | gzip -1 -" | dd of=/dev/vdX
+
+7.  Detach the destination volume from the instance, and check that it has the
+data you want by trying to boot it or attach it to another instance.  If all
+looks correct, you can destroy both temporary instances and you are done.
+
+.. meta::
+    :labels: migrate volume

--- a/source/dreamcompute/tutorials/how-to-migrate-volumes-between-clusters.rst
+++ b/source/dreamcompute/tutorials/how-to-migrate-volumes-between-clusters.rst
@@ -42,7 +42,7 @@ Migrate a Volume using SSH and dd
 
 For this type of move, we will assume you have stopped all services using the
 data on the volume, safely unmounted it on the instance using it, and detached
-it from the instance in the Volumes menu in the dashboard.  
+it from the instance in the Volumes menu in the dashboard.
 
 As an overview, we are going to setup the following to accomplish this task.
 


### PR DESCRIPTION
Documentation that I've tested and written related to migrating instances and volumes from one DreamCompute cluster to another.  The instances one could be broken out into "volume-backed" and "ephemeral" if needed.  Each document is long because it isn't a super easy process.

Any other feedback is welcome.

Everything passed 'tox' and 'aspell -c'.