### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/source/dreamobjects/tutorials/how-to-setup-cross-origin-sharing-on-dreamobjects.rst
+++ b/source/dreamobjects/tutorials/how-to-setup-cross-origin-sharing-on-dreamobjects.rst
@@ -307,7 +307,7 @@ Clients
 -------
 
 * `S3 Browser: Bucket CORS Configuration <http://s3browser.com/s3-bucket-cors-configuration.php>`_
-* `boto: S3 <http://boto.readthedocs.org/en/latest/ref/s3.html>`_
+* `boto: S3 <https://boto.readthedocs.io/en/latest/ref/s3.html>`_
 * `Bucket Explorer: Amazon S3 - Manage Cross-Origin Resource Sharing (CORS) <http://www.bucketexplorer.com/documentation/amazon-s3--manage-cross-origin-resource-sharing.html>`_
 * `CyberDuck: Not supported as of 2015/09/29 <https://trac.cyberduck.io/wiki/help/en/howto/s3>`_
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.