### PR TITLE
Using Figure captions instead of lists in documentation

### DIFF
--- a/source/dreamobjects/tutorials/how-to-use-arq-with-dreamobjects.rst
+++ b/source/dreamobjects/tutorials/how-to-use-arq-with-dreamobjects.rst
@@ -21,7 +21,7 @@ Connecting with Arq on Windows
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 
-1. Lunch Arq:
+1. Launch Arq:
 
     .. figure:: images/Arq-1-win.png
 

--- a/source/dreamobjects/tutorials/how-to-use-arq-with-dreamobjects.rst
+++ b/source/dreamobjects/tutorials/how-to-use-arq-with-dreamobjects.rst
@@ -14,108 +14,105 @@ a password before they're uploaded so your data is protected.
 The installation and configuration of Arq varies depending on the operating
 system.  Click your operating system below to jump to the proper instructions.
 
-    * `Windows <#connecting-with-arq-on-windows>`_
-    * `Mac <#connecting-with-arq-on-mac>`_
+* `Windows <#connecting-with-arq-on-windows>`_
+* `Mac <#connecting-with-arq-on-mac>`_
 
 Connecting with Arq on Windows
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-1. Launch Arq.  When launching Arq for the first time, you are prompted to
+.. figure:: images/Arq-1-win.png
+
+   Launch Arq.  When launching Arq for the first time, you are prompted to
    choose your backup destination type.  Click the 'Other S3-Compatible
    Service' option, and then click **continue**.
 
-.. figure:: images/Arq-1-win.png
+.. figure:: images/Arq-2-win.png
 
-2. For the S3-Compatible Server URL, enter the hostname
+   For the S3-Compatible Server URL, enter the hostname
    'https://objects-us-west-1.dream.io'. Next ensure that the signature version
    defaults to 'Signature Version 2', and then fill in the access and secret
    keys with the values from the DreamHost panel.  Click **continue** to
-   advance to the next step.  Visit the following article for further
-   information about finding your DreamObjects keys:
-
-    * `DreamObjects Keys`_
-
-.. figure:: images/Arq-2-win.png
-
-3. Arq will prompt you to enter a new bucket name, or select an existing
-   bucket.  Choose the option you want and enter a name if necessary, then
-   click **Add** to complete.
+   advance to the next step.  Read how to find your `DreamObjects Keys`_.
 
 .. figure:: images/Arq-3-win.png
 
-4. After your bucket is configured, Arq will ask if you want to setup a new
-   backup schedule, or to restore files from this bucket (which requires
-   existing backups in your bucket).  Click **Set Up Backups**.
+   Arq will prompt you to enter a new bucket name, or select an existing
+   bucket.  Choose the option you want and enter a name if necessary, then
+   click **Add** to complete.
 
 .. figure:: images/Arq-4-win.png
 
-5. Create an encrypted password for your backup which allows additional
-   security for the backup created.
+   After your bucket is configured, Arq will ask if you want to setup a new
+   backup schedule, or to restore files from this bucket (which requires
+   existing backups in your bucket).  Click **Set Up Backups**.
 
 .. figure:: images/Arq-5-win.png
 
-6. After you enter an encrypted password, be sure to write down the password
-   you created and store it somewhere safe.
+   Create an encrypted password for your backup which allows additional
+   security for the backup created.
 
 .. figure:: images/Arq-6-win.png
 
-7. On Windows systems, Arq defaults to backing up the entire C: drive
-   excluding only the Recycle Bin and the pagefile.sys file.
+   After you enter an encrypted password, be sure to write down the password
+   you created and store it somewhere safe.
 
 .. figure:: images/Arq-7-win.png
 
-8. To add or remove files or folders, click the **Edit backup suggestions**
-   button, which will allow you to customize the selection.
-
-    *Arq is now configured to backup your data:*
+   On Windows systems, Arq defaults to backing up the entire C: drive
+   excluding only the Recycle Bin and the pagefile.sys file.
 
 .. figure:: images/Arq-8-win.png
+
+   To add or remove files or folders, click the **Edit backup suggestions**
+   button, which will allow you to customize the selection.
+
+Arq is now configured to backup your data.
+
 
 Connecting with Arq on Mac
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-1. Launch Arq.  When launching Arq for the first time, you are prompted to
+.. figure:: images/Arq-1-mac.png
+
+   Launch Arq.  When launching Arq for the first time, you are prompted to
    choose your backup destination type.  Select 'DreamObjects' from the
    drop-down list.  Fields to enter the access and secret keys will appear
    as well as a button to open the DreamHost panel to find your keys.  Enter
-   your desired keys.  Visit the following article for further information:
-
-    * `DreamObjects Keys`_
-
-.. figure:: images/Arq-1-mac.png
-
-2. After you enter the DreamObjects access Key and secret Key, enter a new
-   bucket name or select an existing bucket from the drop down list.
+   your desired keys.   Read how to find your `DreamObjects Keys`_.
 
 .. figure:: images/Arq-2-mac.png
 
-3. After your bucket is configured, Arq will ask if you want to setup a new
-   backup schedule, or to restore files from this bucket (which requires
-   existing backups in your bucket).  Click **Set Up Backups**.
+   After you enter the DreamObjects access Key and secret Key, enter a new
+   bucket name or select an existing bucket from the drop down list.
 
 .. figure:: images/Arq-3-mac.png
 
-4. Create an encrypted password for your backup which allows additional
-   security for the backup created.
+   After your bucket is configured, Arq will ask if you want to setup a new
+   backup schedule, or to restore files from this bucket (which requires
+   existing backups in your bucket).  Click **Set Up Backups**.
 
 .. figure:: images/Arq-4-mac.png
 
-5. After you enter an encrypted password, be sure to write down the password
-   you created and store it somewhere safe.
+   Create an encrypted password for your backup which allows additional
+   security for the backup created.
 
 .. figure:: images/Arq-5-mac.png
 
-6. On Mac systems, Arq defaults to backing up the /Users directory, excluding
-   files it knows are unnecessary like cache and page files.
+   After you enter an encrypted password, be sure to write down the password
+   you created and store it somewhere safe.
 
 .. figure:: images/Arq-6-mac.png
 
-7. To add or remove files or folders, click the **Edit backup suggestions**
-   button, which will allow you to customize the selection.
-
-    *Arq is now configured to backup your data:*
+   On Mac systems, Arq defaults to backing up the /Users directory, excluding
+   files it knows are unnecessary like cache and page files.
 
 .. figure:: images/Arq-7-mac.png
+
+   To add or remove files or folders, click the **Edit backup suggestions**
+   button, which will allow you to customize the selection.
+
+Arq is now configured to backup your data.
+
 
 .. _DreamObjects Keys: 215986357-What-are-Keys-in-DreamObjects-and-How-Do-You-Use-Them-
 

--- a/source/dreamobjects/tutorials/how-to-use-arq-with-dreamobjects.rst
+++ b/source/dreamobjects/tutorials/how-to-use-arq-with-dreamobjects.rst
@@ -20,51 +20,71 @@ system.  Click your operating system below to jump to the proper instructions.
 Connecting with Arq on Windows
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. figure:: images/Arq-1-win.png
 
-   Launch Arq.  When launching Arq for the first time, you are prompted to
-   choose your backup destination type.  Click the 'Other S3-Compatible
-   Service' option, and then click **continue**.
+1. Lunch Arq:
 
-.. figure:: images/Arq-2-win.png
+    .. figure:: images/Arq-1-win.png
 
-   For the S3-Compatible Server URL, enter the hostname
-   'https://objects-us-west-1.dream.io'. Next ensure that the signature version
-   defaults to 'Signature Version 2', and then fill in the access and secret
-   keys with the values from the DreamHost panel.  Click **continue** to
-   advance to the next step.  Read how to find your `DreamObjects Keys`_.
+       When launching Arq for the first time, you are prompted to
+       choose your backup destination type.  Click the 'Other
+       S3-Compatible Service' option, and then click **continue**.
 
-.. figure:: images/Arq-3-win.png
+2. Enter DreamObject's hostname:
 
-   Arq will prompt you to enter a new bucket name, or select an existing
-   bucket.  Choose the option you want and enter a name if necessary, then
-   click **Add** to complete.
+    .. figure:: images/Arq-2-win.png
 
-.. figure:: images/Arq-4-win.png
+       For the S3-Compatible Server URL, enter the hostname
+       'https://objects-us-west-1.dream.io'. Next ensure that the
+       signature version defaults to 'Signature Version 2', and then
+       fill in the access and secret keys with the values from the
+       DreamHost panel.  Click **continue** to advance to the next
+       step.  Read how to find your `DreamObjects Keys`_.
 
-   After your bucket is configured, Arq will ask if you want to setup a new
-   backup schedule, or to restore files from this bucket (which requires
-   existing backups in your bucket).  Click **Set Up Backups**.
+3. Enter a bucket name:
 
-.. figure:: images/Arq-5-win.png
+    .. figure:: images/Arq-3-win.png
 
-   Create an encrypted password for your backup which allows additional
-   security for the backup created.
+       Arq will prompt you to enter a new bucket name, or select an
+       existing bucket.  Choose the option you want and enter a name
+       if necessary, then click **Add** to complete.
 
-.. figure:: images/Arq-6-win.png
+4. Set up backups:
 
-   After you enter an encrypted password, be sure to write down the password
-   you created and store it somewhere safe.
+    .. figure:: images/Arq-4-win.png
 
-.. figure:: images/Arq-7-win.png
+       After your bucket is configured, Arq will ask if you want to
+       setup a new backup schedule, or to restore files from this
+       bucket (which requires existing backups in your bucket).  Click
+       **Set Up Backups**.
 
-   On Windows systems, Arq defaults to backing up the entire C: drive
-   excluding only the Recycle Bin and the pagefile.sys file.
+5. Encrypt backups:
 
-.. figure:: images/Arq-8-win.png
+    .. figure:: images/Arq-5-win.png
 
-   To add or remove files or folders, click the **Edit backup suggestions**
-   button, which will allow you to customize the selection.
+       Create an encrypted password for your backup which allows
+       additional security for the backup created.
+
+6. Store the encryption password:
+
+    .. figure:: images/Arq-6-win.png
+
+       After you enter an encrypted password, be sure to write down
+       the password you created and store it somewhere safe.
+
+7. Choose the folders to backup:
+
+    .. figure:: images/Arq-7-win.png
+
+       On Windows systems, Arq defaults to backing up the entire C:
+       drive excluding only the Recycle Bin and the pagefile.sys file.
+
+8. Edit backup suggestions:
+
+    .. figure:: images/Arq-8-win.png
+
+       To add or remove files or folders, click the **Edit backup
+       suggestions** button, which will allow you to customize the
+       selection.
 
 Arq is now configured to backup your data.
 
@@ -72,44 +92,63 @@ Arq is now configured to backup your data.
 Connecting with Arq on Mac
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. figure:: images/Arq-1-mac.png
+1. Launch Arq
 
-   Launch Arq.  When launching Arq for the first time, you are prompted to
-   choose your backup destination type.  Select 'DreamObjects' from the
-   drop-down list.  Fields to enter the access and secret keys will appear
-   as well as a button to open the DreamHost panel to find your keys.  Enter
-   your desired keys.   Read how to find your `DreamObjects Keys`_.
+    .. figure:: images/Arq-1-mac.png
 
-.. figure:: images/Arq-2-mac.png
+       Launch Arq.  When launching Arq for the first time, you are
+       prompted to choose your backup destination type.  Select
+       'DreamObjects' from the drop-down list.  Fields to enter the
+       access and secret keys will appear as well as a button to open
+       the DreamHost panel to find your keys.  Enter your desired
+       keys.  Read how to find your `DreamObjects Keys`_.
 
-   After you enter the DreamObjects access Key and secret Key, enter a new
-   bucket name or select an existing bucket from the drop down list.
+2. Select bucket or create one:
 
-.. figure:: images/Arq-3-mac.png
+    .. figure:: images/Arq-2-mac.png
 
-   After your bucket is configured, Arq will ask if you want to setup a new
-   backup schedule, or to restore files from this bucket (which requires
-   existing backups in your bucket).  Click **Set Up Backups**.
+       After you enter the DreamObjects access Key and secret Key,
+       enter a new bucket name or select an existing bucket from the
+       drop down list.
 
-.. figure:: images/Arq-4-mac.png
+3. Set up backups:
 
-   Create an encrypted password for your backup which allows additional
-   security for the backup created.
+    .. figure:: images/Arq-3-mac.png
 
-.. figure:: images/Arq-5-mac.png
+       After your bucket is configured, Arq will ask if you want to
+       setup a new backup schedule, or to restore files from this
+       bucket (which requires existing backups in your bucket).  Click
+       **Set Up Backups**.
 
-   After you enter an encrypted password, be sure to write down the password
-   you created and store it somewhere safe.
+4. Encrypt backup:
 
-.. figure:: images/Arq-6-mac.png
+    .. figure:: images/Arq-4-mac.png
 
-   On Mac systems, Arq defaults to backing up the /Users directory, excluding
-   files it knows are unnecessary like cache and page files.
+       Create an encrypted password for your backup which allows
+       additional security for the backup created.
 
-.. figure:: images/Arq-7-mac.png
+5. Store your password:
 
-   To add or remove files or folders, click the **Edit backup suggestions**
-   button, which will allow you to customize the selection.
+    .. figure:: images/Arq-5-mac.png
+
+       After you enter an encrypted password, be sure to write down
+       the password you created and store it somewhere safe.
+
+6. Choose the folders to backup:
+
+    .. figure:: images/Arq-6-mac.png
+
+       On Mac systems, Arq defaults to backing up the /Users
+       directory, excluding files it knows are unnecessary like cache
+       and page files.
+
+7. Edit backup suggestions:
+
+    .. figure:: images/Arq-7-mac.png
+
+       To add or remove files or folders, click the **Edit backup
+       suggestions** button, which will allow you to customize the
+       selection.
 
 Arq is now configured to backup your data.
 

--- a/source/dreamobjects/tutorials/how-to-use-arq-with-dreamobjects.rst
+++ b/source/dreamobjects/tutorials/how-to-use-arq-with-dreamobjects.rst
@@ -25,66 +25,66 @@ Connecting with Arq on Windows
 
     .. figure:: images/Arq-1-win.png
 
-       When launching Arq for the first time, you are prompted to
-       choose your backup destination type.  Click the 'Other
-       S3-Compatible Service' option, and then click **continue**.
+        When launching Arq for the first time, you are prompted to
+        choose your backup destination type.  Click the 'Other
+        S3-Compatible Service' option, and then click **continue**.
 
 2. Enter DreamObject's hostname:
 
     .. figure:: images/Arq-2-win.png
 
-       For the S3-Compatible Server URL, enter the hostname
-       'https://objects-us-west-1.dream.io'. Next ensure that the
-       signature version defaults to 'Signature Version 2', and then
-       fill in the access and secret keys with the values from the
-       DreamHost panel.  Click **continue** to advance to the next
-       step.  Read how to find your `DreamObjects Keys`_.
+        For the S3-Compatible Server URL, enter the hostname
+        'https://objects-us-west-1.dream.io'. Next ensure that the
+        signature version defaults to 'Signature Version 2', and then
+        fill in the access and secret keys with the values from the
+        DreamHost panel.  Click **continue** to advance to the next
+        step.  Read how to find your `DreamObjects Keys`_.
 
 3. Enter a bucket name:
 
     .. figure:: images/Arq-3-win.png
 
-       Arq will prompt you to enter a new bucket name, or select an
-       existing bucket.  Choose the option you want and enter a name
-       if necessary, then click **Add** to complete.
+        Arq will prompt you to enter a new bucket name, or select an
+        existing bucket.  Choose the option you want and enter a name
+        if necessary, then click **Add** to complete.
 
 4. Set up backups:
 
     .. figure:: images/Arq-4-win.png
 
-       After your bucket is configured, Arq will ask if you want to
-       setup a new backup schedule, or to restore files from this
-       bucket (which requires existing backups in your bucket).  Click
-       **Set Up Backups**.
+        After your bucket is configured, Arq will ask if you want to
+        setup a new backup schedule, or to restore files from this
+        bucket (which requires existing backups in your bucket).  Click
+        **Set Up Backups**.
 
 5. Encrypt backups:
 
     .. figure:: images/Arq-5-win.png
 
-       Create an encrypted password for your backup which allows
-       additional security for the backup created.
+        Create an encrypted password for your backup which allows
+        additional security for the backup created.
 
 6. Store the encryption password:
 
     .. figure:: images/Arq-6-win.png
 
-       After you enter an encrypted password, be sure to write down
-       the password you created and store it somewhere safe.
+        After you enter an encrypted password, be sure to write down
+        the password you created and store it somewhere safe.
 
 7. Choose the folders to backup:
 
     .. figure:: images/Arq-7-win.png
 
-       On Windows systems, Arq defaults to backing up the entire C:
-       drive excluding only the Recycle Bin and the pagefile.sys file.
+        On Windows systems, Arq defaults to backing up the entire C:
+        drive excluding only the Recycle Bin and the pagefile.sys file.
 
 8. Edit backup suggestions:
 
     .. figure:: images/Arq-8-win.png
 
-       To add or remove files or folders, click the **Edit backup
-       suggestions** button, which will allow you to customize the
-       selection.
+        To add or remove files or folders, click the **Edit backup
+        suggestions** button, which will allow you to customize the
+        selection.
 
 Arq is now configured to backup your data.
 
@@ -96,59 +96,59 @@ Connecting with Arq on Mac
 
     .. figure:: images/Arq-1-mac.png
 
-       Launch Arq.  When launching Arq for the first time, you are
-       prompted to choose your backup destination type.  Select
-       'DreamObjects' from the drop-down list.  Fields to enter the
-       access and secret keys will appear as well as a button to open
-       the DreamHost panel to find your keys.  Enter your desired
-       keys.  Read how to find your `DreamObjects Keys`_.
+        Launch Arq.  When launching Arq for the first time, you are
+        prompted to choose your backup destination type.  Select
+        'DreamObjects' from the drop-down list.  Fields to enter the
+        access and secret keys will appear as well as a button to open
+        the DreamHost panel to find your keys.  Enter your desired
+        keys.  Read how to find your `DreamObjects Keys`_.
 
 2. Select bucket or create one:
 
     .. figure:: images/Arq-2-mac.png
 
-       After you enter the DreamObjects access Key and secret Key,
-       enter a new bucket name or select an existing bucket from the
-       drop down list.
+        After you enter the DreamObjects access Key and secret Key,
+        enter a new bucket name or select an existing bucket from the
+        drop down list.
 
 3. Set up backups:
 
     .. figure:: images/Arq-3-mac.png
 
-       After your bucket is configured, Arq will ask if you want to
-       setup a new backup schedule, or to restore files from this
-       bucket (which requires existing backups in your bucket).  Click
-       **Set Up Backups**.
+        After your bucket is configured, Arq will ask if you want to
+        setup a new backup schedule, or to restore files from this
+        bucket (which requires existing backups in your bucket).  Click
+        **Set Up Backups**.
 
 4. Encrypt backup:
 
     .. figure:: images/Arq-4-mac.png
 
-       Create an encrypted password for your backup which allows
-       additional security for the backup created.
+        Create an encrypted password for your backup which allows
+        additional security for the backup created.
 
 5. Store your password:
 
     .. figure:: images/Arq-5-mac.png
 
-       After you enter an encrypted password, be sure to write down
-       the password you created and store it somewhere safe.
+        After you enter an encrypted password, be sure to write down
+        the password you created and store it somewhere safe.
 
 6. Choose the folders to backup:
 
     .. figure:: images/Arq-6-mac.png
 
-       On Mac systems, Arq defaults to backing up the /Users
-       directory, excluding files it knows are unnecessary like cache
-       and page files.
+        On Mac systems, Arq defaults to backing up the /Users
+        directory, excluding files it knows are unnecessary like cache
+        and page files.
 
 7. Edit backup suggestions:
 
     .. figure:: images/Arq-7-mac.png
 
-       To add or remove files or folders, click the **Edit backup
-       suggestions** button, which will allow you to customize the
-       selection.
+        To add or remove files or folders, click the **Edit backup
+        suggestions** button, which will allow you to customize the
+        selection.
 
 Arq is now configured to backup your data.
 


### PR DESCRIPTION
Lists, ordered and unordered, seem to create issues with zendesk
rendering of the output html. Instead of lists, it's preferrable
to use image caption in the .. figure:: directive.

This document is a first attempt at using this tecnique. The output
is also compliant with styleguide where they require the image to be
shown *before* the text describing the actions to take.