### PR TITLE
Mention "core" username for CoreOS where appropriate (fixes issue #35)

### DIFF
--- a/source/dreamcompute/gettingstarted/connect-to-an-instance-with-ssh-keys.rst
+++ b/source/dreamcompute/gettingstarted/connect-to-an-instance-with-ssh-keys.rst
@@ -36,7 +36,8 @@ field.  Select the .ppk file you generated and then
 click open.  You can now navigate to the "Session"
 setting page, and enter into the host name field
 "dhc-user@" followed immediately by your instance's
-public ip address.  Click Open to start your session.
+public ip address.  If using CoreOS, use "core@" instead
+of "dhc-user@".  Click Open to start your session.
 
 Using Mac & Linux
 -----------------
@@ -58,7 +59,8 @@ first.  There are several ways to do this:
         Host IPADDRESS
         IdentityFile ~/path/to/key
 
-The final step is to connect via ssh:
+The final step is to connect via ssh (replace "dhc-user" with "core" if using
+CoreOS):
 
 .. code-block:: bash
 

--- a/source/dreamcompute/tutorials/how-to-create-and-mount-volumes-on-dreamcompute.rst
+++ b/source/dreamcompute/tutorials/how-to-create-and-mount-volumes-on-dreamcompute.rst
@@ -144,7 +144,8 @@ The new drive now needs a file system so that it can store data.  There are
 many choices when it comes to file systems, but for this example we'll use a
 safe default of ext4.
 
-Now connect to your instance with the dhc-user username.
+Now connect to your instance with the dhc-user username (or the "core" username
+if using CoreOS).
 
 We first need to find the device name for our new volume.  You can see what
 devices are available by checking for /dev/vd* device files:


### PR DESCRIPTION
Mention the "core" username for CoreOS on articles that are appropriate for it, such as connecting via SSH, and mounting volumes.  No changes made to articles that are unlikely to be used in combination with CoreOS like LAMP, trellis, owncloud, etc.