### PR TITLE
Add warning for changing file titles

### DIFF
--- a/check-labels.sh
+++ b/check-labels.sh
@@ -1,12 +1,27 @@
 #!/bin/bash
 
-files="`find ./source/dream*/*/*.rst | egrep -v '\/common\/.*\.rst' | xargs -I FILE grep -L ':labels:' FILE`"
+changedfiles="$(git diff HEAD --name-only | egrep '^source\/dream.*\/.*\/.*\.rst$')"
+titleschanged="0"
+for file in $changedfiles; do
+    numschanged="$(git diff HEAD --unified=0 "$file" | sed -n 5p)"
+    lineschanged="$(echo "$numschanged" | awk '{print $2}' | cut -d ',' -f1 | cut -d '-' -f2- | cut -d '+' -f2-)"
+    if [ "$lineschanged" -le 3 ] ; then
+        titleschanged="1"
+    fi
+done
+if [ "$titleschanged" -eq 1 ] ; then
+    echo "WARNING YOU MAY BE CHANGING AN ARTICLE TITLE, ONLY CHANGE AN"
+    echo "ARTICLE TITLE IF YOU ARE ENTIRELY SURE OF HOW TO DO SO"
+    echo "For more info see 'Gotchas of contributing' in the README"
+fi
 
-if [ -z "$files" ] ; then
+filesmissinglabels="`find ./source/dream*/*/*.rst | egrep -v '\/common\/.*\.rst' | xargs -I FILE grep -L ':labels:' FILE`"
+
+if [ -z "$filesmissinglabels" ] ; then
     echo "All articles have labels"
     exit 0
 else
-    for file in $files ; do
+    for file in $filesmissinglabels ; do
         echo "$file"
     done
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.6
-envlist = checksyntax, html
+envlist = html, checksyntax
 skipsdist = True
 
 [testenv]
@@ -28,6 +28,6 @@ commands = sphinx-build -W -E -b html -d {toxinidir}/build/doctrees  {toxinidir}
 [testenv:checksyntax]
 commands =
         # checks presence of labels in files
-        ./check-labels.sh
         # checks rst conventions
         doc8 source
+        ./check-labels.sh


### PR DESCRIPTION
This will add a small warning when running `tox` if one of the changes you have (not commited yet) changes the title of an article.